### PR TITLE
fix: check transfer instead of performance for used program stages

### DIFF
--- a/src/hooks/programStages/useGetUsedPProgramStages.ts
+++ b/src/hooks/programStages/useGetUsedPProgramStages.ts
@@ -5,6 +5,6 @@ const useGetUsedProgramStages = () => {
     const { performance, "final-result": finalResult, "socio-economics": socioEconomics, registration, transfer } = dataStoreData;
     const performanceProgramStages = performance?.programStages?.map((programStage: any) => programStage?.programStage) ?? [];
 
-    return performance ? [...performanceProgramStages, finalResult?.programStage, socioEconomics?.programStage, registration?.programStage, transfer?.programStage] : []
+    return transfer ? [...performanceProgramStages, finalResult?.programStage, socioEconomics?.programStage, registration?.programStage, transfer?.programStage] : []
 }
 export default useGetUsedProgramStages


### PR DESCRIPTION
The hook was incorrectly using the presence of `performance` data to determine whether to return program stages. This could cause the hook to return an empty array even when other program stages (like transfer) are available. The condition now checks for `transfer` data, ensuring all relevant program stages are included when transfer data exists.