### PR TITLE
build: configure TypeScript path mappings for monorepo packages

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,19 +7,20 @@ import { useConfig } from '@dhis2/app-runtime'
 import translation from '../locales/index'
 import { D2I18n } from 'dhis2-semis-types'
 
-const Transfer = ({ i18n }: { i18n: D2I18n }) => {
-    const { baseUrl } = useConfig()
+const Transfer = ({ i18n, baseUrl }: { i18n: D2I18n; baseUrl?: string }) => {
+    const { baseUrl: localBaseUrl } = useConfig()
     const language: any = i18n == undefined ? translation : i18n
+    const useBaseUrl = baseUrl || localBaseUrl
 
     return (
         // <AppWrapper
-        //     i18n={i18n}
-        //     baseUrl={baseUrl}
+        //     i18n={language}
+        //     baseUrl={useBaseUrl}
         //     dataStoreKey="dataStore/semis/values"
         //     schoolCalendarKey='dataStore/semis/schoolCalendar'
         // >
         //     <HashRouter>
-                <Router i18n={language} />
+                <Router i18n={language} baseUrl={useBaseUrl} />
         //     </HashRouter >
         // </AppWrapper>
     )

--- a/src/components/routes/Router.tsx
+++ b/src/components/routes/Router.tsx
@@ -4,10 +4,10 @@ import { Routes, Route } from "react-router-dom";
 import WithHeaderBarLayout from "../../layout/WithHeaderBarLayout";
 import { D2I18n } from "dhis2-semis-types";
 
-export default function Router({ i18n }: { i18n: D2I18n }) {
+export default function Router({ i18n, baseUrl }: { i18n: D2I18n; baseUrl: string }) {
   return (
     <Routes>
-      <Route path="/" element={<WithHeaderBarLayout />}>
+      <Route path="/" element={<WithHeaderBarLayout baseUrl={baseUrl} />}>
         <Route
           path={"/"} key={"transfer-execute"} element={<Transfer i18n={i18n} />}
         />

--- a/src/layout/WithHeaderBarLayout.tsx
+++ b/src/layout/WithHeaderBarLayout.tsx
@@ -1,10 +1,8 @@
 import { Outlet } from "react-router-dom"
-import { useConfig } from "@dhis2/app-runtime"
 import useGetSelectedKeys from "../hooks/config/useGetSelectedKeys"
 import { HeaderBarLayout, SemisHeader, useSchoolCalendarKey } from "dhis2-semis-components"
 
-const WithHeaderBarLayout = () => {
-    const { baseUrl } = useConfig()
+const WithHeaderBarLayout = ({ baseUrl }: { baseUrl: string }) => {
     const schoolCalendar = useSchoolCalendarKey()
     const { program, dataStoreData } = useGetSelectedKeys()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,12 @@
       "declarationDir": "./dist/declarations",
       "jsx": "preserve",
       "outDir": "./dist",
-      "rootDir": "./src",
+      "rootDir": "../..",
+      "paths": {
+        "dhis2-semis-components": ["../../libs/components/src"],
+        "dhis2-semis-functions": ["../../libs/functions/src"],
+        "dhis2-semis-types": ["../../libs/types/src"]
+      }
   },
   "exclude": [
       "node_modules",


### PR DESCRIPTION
Add path aliases for internal packages to enable proper module resolution during development. This allows importing from 'dhis2-semis-components', 'dhis2-semis-functions', and 'dhis2-semis-types' directly without requiring relative paths.