### PR TITLE
fix(events): change trackedEntity to trackedEntities in API call

### DIFF
--- a/src/hooks/events/useGetEventsByEnrollment.ts
+++ b/src/hooks/events/useGetEventsByEnrollment.ts
@@ -14,7 +14,7 @@ export function useGetEventsByEnrollment() {
             setLoading(true);
 
             const eventPromises = programStagesToTransfer?.map(stage =>
-                getEvents({ program: dataStoreData?.program, programStage: stage, trackedEntity, fields: "*" })
+                getEvents({ program: dataStoreData?.program, programStage: stage, trackedEntities: trackedEntity, fields: "*" })
                     .then((response: any) => {
                         const event = response?.filter(
                             (instance: any) => instance.enrollment === enrollment


### PR DESCRIPTION
The API endpoint expects the parameter to be named `trackedEntities` (plural) instead of `trackedEntity`. This ensures the hook correctly fetches events for the specified tracked entity.