### PR TITLE
fix(orgunits): remove paging false from org unit query

### DIFF
--- a/src/hooks/orgUnits/useGetOrgUnits.ts
+++ b/src/hooks/orgUnits/useGetOrgUnits.ts
@@ -8,7 +8,6 @@ const ORGUNIT_QUERY: any = {
             fields: [
                 "id,name"
             ],
-            paging: false
         }
     }
 }


### PR DESCRIPTION
This change enables pagination for the org unit query, which will improve performance when dealing with large datasets by fetching data in manageable chunks.