### PR TITLE
fix: increase default page size from 5 to 50 for transfer list

### DIFF
--- a/src/pages/transfer/Transfer.tsx
+++ b/src/pages/transfer/Transfer.tsx
@@ -20,7 +20,7 @@ const Transfer = ({ i18n }: { i18n: D2I18n }) => {
   const { dataStoreData, program: programData } = useGetSelectedKeys()
   const { getData, loading } = useTableData({ module: Modules.Transfer });
   const { school, schoolName, position, sectionType, academicYear } = urlParameters;
-  const [pagination, setPagination] = useState({ page: 1, pageSize: 5, totalPages: 0, totalElements: 0 });
+  const [pagination, setPagination] = useState({ page: 1, pageSize: 50, totalPages: 0, totalElements: 0 });
   const { getOuDisplayName, loaading: loadingOU } = OuNameContainer({ dataStoreData, setData, setModalDetails });
   const { columns } = useHeader({ dataStoreData, programConfigData: programData as unknown as ProgramConfig, programStage: dataStoreData?.transfer?.programStage });
   const [filterState, setFilterState] = useState<{ dataElements: any; attributes: any; }>({ attributes: [], dataElements: [] });


### PR DESCRIPTION
Improve user experience by showing more items per page by default, reducing the need for pagination in typical usage scenarios.